### PR TITLE
Add insecure (http) mode to OpenWeather

### DIFF
--- a/OpenWeather.cpp
+++ b/OpenWeather.cpp
@@ -33,7 +33,7 @@
 // Pass a nullptr for current, hourly or daily pointers to exclude in response.
 bool OW_Weather::getForecast(OW_current *current, OW_hourly *hourly, OW_daily *daily,
                              String api_key, String latitude, String longitude,
-                             String units, String language) {
+                             String units, String language, bool secure) {
 
   data_set = "";
   hourly_index = 0;
@@ -51,6 +51,7 @@ bool OW_Weather::getForecast(OW_current *current, OW_hourly *hourly, OW_daily *d
   if (!daily)    exclude += "daily,";
 
   String url = "https://api.openweathermap.org/data/2.5/onecall?lat=" + latitude + "&lon=" + longitude + "&exclude=minutely," + exclude + "&units=" + units + "&lang=" + language + "&appid=" + api_key;
+bool Secure = secure;
 
   // Send GET request and feed the parser
   bool result = parseRequest(url);
@@ -82,18 +83,30 @@ bool OW_Weather::parseRequest(String url) {
 
   uint32_t dt = millis();
 
-  WiFiClientSecure client;
-
-  JSON_Decoder parser;
-  parser.setListener(this);
-
   const char*  host = "api.openweathermap.org";
+  // Must use namespace:: to select BearSSL
+if(secure){
+    BearSSL::WiFiClientSecure client;
 
+  client.setInsecure();
   if (!client.connect(host, 443))
   {
     Serial.println("Connection failed.");
     return false;
   }
+}else{
+  WiFiClient client;
+  if (!client.connect(host, 80))
+  {
+    Serial.println("Connection failed.");
+    return false;
+  }
+}
+
+  JSON_Decoder parser;
+  parser.setListener(this);
+
+
 
   uint32_t timeout = millis();
   char c = 0;
@@ -173,21 +186,23 @@ bool OW_Weather::parseRequest(String url) {
 
   uint32_t dt = millis();
 
+  const char*  host = "api.openweathermap.org";
   // Must use namespace:: to select BearSSL
-  BearSSL::WiFiClientSecure client;
+if(Secure){
+    BearSSL::WiFiClientSecure client;
 
   client.setInsecure();
-
-  JSON_Decoder parser;
-  parser.setListener(this);
-
-  const char*  host = "api.openweathermap.org";
-
   if (!client.connect(host, 443))
   {
     Serial.println("Connection failed.");
     return false;
-  }
+
+ JSON_Decoder parser;
+  parser.setListener(this);
+
+
+
+
 
   uint32_t timeout = millis();
   char c = 0;
@@ -255,7 +270,97 @@ bool OW_Weather::parseRequest(String url) {
   return parseOK;
 }
 
-#endif // ESP32 or ESP8266 parseRequest
+
+}
+
+
+  
+if(!Secure){
+  WiFiClient client;
+  if (!client.connect(host, 80))
+  {
+    Serial.println("Connection failed.");
+    return false;
+  }
+
+ JSON_Decoder parser;
+  parser.setListener(this);
+
+
+
+
+
+  uint32_t timeout = millis();
+  char c = 0;
+  parseOK = false;
+
+#ifdef SHOW_JSON
+  int ccount = 0;
+#endif
+
+  // Send GET request
+  Serial.println("Sending GET request to api.openweathermap.org...");
+  client.print(String("GET ") + url + " HTTP/1.1\r\n" + "Host: " + host + "\r\n" + "Connection: close\r\n\r\n");
+
+  // Pull out any header, X-Forecast-API-Calls: reports current daily API call count
+  while (client.available() || client.connected())
+  {
+    String line = client.readStringUntil('\n');
+    if (line == "\r") {
+      Serial.println("Header end found");
+      break;
+    }
+
+    Serial.println(line);
+
+    if ((millis() - timeout) > 5000UL)
+    {
+      Serial.println ("HTTP header timeout");
+      client.stop();
+      return false;
+    }
+  }
+
+  Serial.println("Parsing JSON");
+  
+  // Parse the JSON data, available() includes yields
+  while (client.available() || client.connected())
+  {
+    while (client.available())
+    {
+      c = client.read();
+      parser.parse(c);
+  #ifdef SHOW_JSON
+      if (c == '{' || c == '[' || c == '}' || c == ']') Serial.println();
+      Serial.print(c); if (ccount++ > 100 && c == ',') {ccount = 0; Serial.println();}
+  #endif
+    }
+
+    if ((millis() - timeout) > 8000UL)
+    {
+      Serial.println ("JSON client timeout");
+      parser.reset();
+      client.stop();
+      return false;
+    }
+  }
+
+  Serial.println("");
+  Serial.print("Done in "); Serial.print(millis()-dt); Serial.println(" ms\n");
+
+  parser.reset();
+
+  client.stop();
+  
+  // A message has been parsed without error but the data-point correctness is unknown
+  return parseOK;
+
+}
+
+
+}
+
+ #endif // ESP32 or ESP8266 parseRequest
 
 /***************************************************************************************
 ** Function name:           key etc


### PR DESCRIPTION
I was working on a simple project and tried to get the weather. The problem was, this caused a stack overflow error, because of a core flaw in the BearSSL (my best understanding is that it times out and fills the stack, the reason it crashed is that I had little stack available) So I decided to modify the library to pass another parameter in the function called secure. When it is set to false, the client is not declared with BearSSL, but just a standard WIFIClient. When it is true, there is no modification to the original code.

Secure GET
ow.getForecast(current, hourly, daily, api_key, latitude, longitude, units, language, true);

Insecure and lighter GET
ow.getForecast(current, hourly, daily, api_key, latitude, longitude, units, language, false)

New parameter:
ow.getForecast(current, hourly, daily, api_key, latitude, longitude, units, language, -->bool<--)